### PR TITLE
fix function to get events from contract

### DIFF
--- a/src/cljs_web3_next/helpers.cljs
+++ b/src/cljs_web3_next/helpers.cljs
@@ -31,10 +31,9 @@
   (js->cljkk signature))
 
 (defn event-interface [contract-instance event-key]
-  (reduce (fn [_ element]
-            (when (= (:name element) (-> event-key camel-case name))
-              (reduced element)))
-          (js->cljk (aget contract-instance "_jsonInterface") )))
+  (let [event-name (-> event-key camel-case name)]
+    (first (filter #(= (:name %) event-name)
+                   (js->cljk (aget contract-instance "_jsonInterface"))))))
 
 (defn return-values->clj [return-values {:keys [:inputs] :as event-interface}]
   (reduce (fn [res value]


### PR DESCRIPTION
The function event-interface, which is used for getting the event description from contracts, is not finding all events.
In the way it is currently implemented, it ignores the first element of the collection (i.e., the first event/function defined in the contract abi). Therefore, if the first element happens to be the event we are looking for, it will not find it.

This PR fixes that issue.