### PR TITLE
Clean up web3 creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ yarn-error.log
 .shadow-cljs
 .cpcache
 Session.vim*
+browser-tests-output
+.shadow-cljs

--- a/test/tests/web3_tests.cljs
+++ b/test/tests/web3_tests.cljs
@@ -50,6 +50,7 @@
                                                         (is (= "3" (:new-value (web3-helpers/return-values->clj (aget event "returnValues") event-interface))))))
 
                    event-signature (:signature event-interface)
+                   initial-logs (<! (web3-eth/get-past-logs web3 {:address [address] :topics [event-signature] :from-block block-number :to-block "latest"}))
                    event-log-emitter (web3-eth/subscribe-logs
                                       web3
                                       {:address [address]
@@ -64,7 +65,8 @@
                    seven (<! (web3-eth/contract-call my-contract :my-plus [3 4] {:from (first accounts)}))
                    tx-receipt (<! (web3-eth/get-transaction-receipt web3 (aget tx "transactionHash")))
                    past-events (<! (web3-eth/get-past-events my-contract :SetCounterEvent {:from-block 0 :to-block "latest"}))
-                   past-logs (<! (web3-eth/get-past-logs web3 {:address [address] :topics [event-signature] :from-block block-number :to-block "latest"}))]
+                   final-logs (<! (web3-eth/get-past-logs web3 {:address [address] :topics [event-signature] :from-block block-number :to-block "latest"}))
+                   new-logs (- (count final-logs) (count initial-logs))]
 
 
                (is (= "7" seven))
@@ -76,7 +78,7 @@
                (is (int? block-number))
                (is (map? block))
                (is (= "3" (:new-value (web3-helpers/return-values->clj (aget past-events "0" "returnValues") event-interface))))
-               (is (= 1 (count past-logs)))
+               (is (= 1 new-logs))
 
                (web3-eth/unsubscribe event-emitter)
                (web3-eth/unsubscribe event-log-emitter)


### PR DESCRIPTION
The reason behind this change is to make cljs-web3-next the central place to
obtain the web3 instance. This library will load the Web3.js (has it as
a dependency) and others who want to use it only need to provide info
about the provider (how to connect to the network).

This can be done via
1. providing URL of the node to connect to
2. passing the provider instance (e.g. `window.ethereum` after authorization)