### PR TITLE
Adjusted contract-new and some utils

### DIFF
--- a/src/cljs_web3_next/core.cljs
+++ b/src/cljs_web3_next/core.cljs
@@ -147,21 +147,15 @@
 
   Parameters:
   string  - An ASCII string to be converted to HEX.
-  padding - (optional) The number of bytes the returned HEX string should have.
   Web3    - (optional first argument) Web3 JavaScript object.
 
   Example:
   user> `(from-ascii \"ethereum\")`
   \"0x657468657265756d\"
-  user> `(from-ascii \"ethereum\")`
-  \"0x657468657265756d000000000000000000000000000000000000000000000000\"
-
-  NOTE: The latter is intended behaviour. Because of a bug in Web3 the padding
-        is not added. See https://github.com/ethereum/web3.js/issues/337"
-  ([string] (from-ascii string nil))
-  ([string padding] (from-ascii (default-web3)  string padding))
-  ([Web3 string padding]
-   (ocall+ Web3 "utils" "fromAscii" string padding)))
+  "
+  ([string] (from-ascii (default-web3) string))
+  ([Web3 string]
+   (ocall+ Web3 ["utils" "asciiToHex"] string)))
 
 
 (defn to-decimal
@@ -178,7 +172,7 @@
   21"
   ([hex-string] (to-decimal (default-web3) hex-string))
   ([Web3 hex-string]
-   (ocall+ Web3 "utils" "hexToNumber" hex-string)))
+   (ocall+ Web3 ["utils" "hexToNumber"] hex-string)))
 
 (defn from-decimal
   "Converts a number or number string to its HEX representation.
@@ -194,13 +188,13 @@
   \"0x15\""
   ([number] (from-decimal (default-web3)  number))
   ([Web3 number]
-   (ocall+ Web3 "utils" "numberToHex" number)))
+   (ocall+ Web3 ["utils" "numberToHex"] number)))
 
 (defn from-wei
   "Converts a number of Wei into an Ethereum unit.
 
   Parameters:
-  number - A number or BigNumber instance.
+  number - A string or BigNumber instance.
   unit   - One of :noether :wei :kwei :Kwei :babbage :femtoether :mwei :Mwei
            :lovelace :picoether :gwei :Gwei :shannon :nanoether :nano :szabo
            :microether :micro :finney :milliether :milli :ether :kether :grand
@@ -211,17 +205,17 @@
   given number parameter.
 
   Example:
-  user> `(web3/from-wei 10 :ether)`
+  user> `(web3/from-wei \"10\" :ether)`
   \"0.00000000000000001\""
   ([number unit] (from-wei (default-web3) number unit))
   ([Web3 number unit]
-   (ocall+ Web3 "utils" "fromWei" number (name unit))))
+   (ocall+ Web3 ["utils" "fromWei"] number (name unit))))
 
 (defn to-wei
   "Converts an Ethereum unit into Wei.
 
   Parameters:
-  number - A number or BigNumber instance.
+  number - A string or BigNumber instance.
   unit   - One of :noether :wei :kwei :Kwei :babbage :femtoether :mwei :Mwei
            :lovelace :picoether :gwei :Gwei :shannon :nanoether :nano :szabo
            :microether :micro :finney :milliether :milli :ether :kether :grand
@@ -232,11 +226,11 @@
   given number parameter.
 
   Example:
-  user> `(web3/to-wei 10 :ether)`
+  user> `(web3/to-wei \"10\" :ether)`
   \"10000000000000000000\""
   ([number unit] (to-wei (default-web3) number unit))
   ([Web3 number unit]
-   (ocall+ Web3 "utils" "toWei" number (name unit))))
+   (ocall+ Web3 ["utils" "toWei"] number (name unit))))
 
 (defn to-big-number
   "Converts a given number into a BigNumber instance.
@@ -244,7 +238,7 @@
   renamed to toBN in 1.0
 
   Parameters:
-  number-or-hex-string - A number, number string or HEX string of a number.
+  number-or-hex-string - A number string or HEX string of a number.
   Web3                 - (optional first argument) Web3 JavaScript object.
 
   Example:
@@ -252,7 +246,7 @@
   <An instance of BigNumber>"
   ([number-or-hex-string] (to-big-number (default-web3) number-or-hex-string))
   ([Web3 number-or-hex-string]
-   (ocall+ Web3 "utils" "toBN" number-or-hex-string)))
+   (ocall+ Web3 ["utils" "toBN"] number-or-hex-string)))
 
 (defn pad-left
   "Returns input string with zeroes or sign padded to the left.
@@ -272,7 +266,7 @@
   ([string chars] (pad-left string chars nil))
   ([string chars sign] (pad-left (default-web3) string chars sign))
   ([Web3 string chars sign]
-   (ocall+ Web3 "utils" "padLeft" string chars sign)))
+   (ocall+ Web3 ["utils" "padLeft"] string chars sign)))
 
 (defn pad-right
   "Returns input string with zeroes or sign padded to the right.
@@ -292,7 +286,7 @@
   ([string chars] (pad-right string chars nil))
   ([string chars sign] (pad-right (default-web3) string chars sign))
   ([Web3 string chars sign]
-   (ocall+ Web3 "utils" "padRight" string chars sign)))
+   (ocall+ Web3 ["utils" "padRight"] string chars sign)))
 
 (defn address?
   "Returns a boolean indicating if the given string is an address.
@@ -314,7 +308,7 @@
   false"
   ([address] (address? (default-web3) address))
   ([Web3 address]
-   (ocall+ Web3 "utils" "isAddress" [address])))
+   (ocall+ Web3 ["utils" "isAddress"] address)))
 
 (defn reset
   "Should be called to reset the state of web3. Resets everything except the manager.

--- a/test/tests/web3_tests.cljs
+++ b/test/tests/web3_tests.cljs
@@ -98,3 +98,29 @@
                       (web3-utils/address->checksum web3 "0x00dc857b6f66bf96154ff4541e4a2fe87e3db6fc")))
 
                (done))))))
+
+
+(deftest test-web3-utils
+  []
+  (is (= (web3-core/sha3 "Some string to be hashed")
+          "0xed973b234cf2238052c9ac87072c71bcf33abc1bbd721018e0cca448ef79b379"))
+  (is (= (web3-core/to-hex "foo") "0x666f6f"))
+  (is (= (web3-core/to-ascii "0x666f6f") "foo"))
+  (is (= (web3-core/from-ascii "ethereum") "0x657468657265756d"))
+  (is (= (web3-core/to-decimal "0x15") 21))
+  (is (= (web3-core/from-decimal 21) "0x15"))
+  (is (= (web3-core/from-wei "10" :ether) "0.00000000000000001"))
+  (is (= (web3-core/to-wei "10" :ether) "10000000000000000000"))
+  (is (= (str (web3-core/to-big-number "10000000000000000000")) "10000000000000000000"))
+  (is (= (web3-core/pad-left "foo" 8) "00000foo"))
+  (is (= (web3-core/pad-right "foo" 8 "b") "foobbbbb"))
+  (is (web3-core/address? "0x8888f1f195afa192cfee860698584c030f4c9db1"))
+  (is (not (web3-core/address? "0x8888F1f195afa192cfee860698584c030f4c9db1")))
+
+  (let [provider (get-web3-provider (running-in-browser?))
+     web3 (new Web3 provider)]
+    (is (= (web3-utils/solidity-sha3 web3 "Some string to be hashed")
+          "0xed973b234cf2238052c9ac87072c71bcf33abc1bbd721018e0cca448ef79b379"))
+
+    (is (= (web3-utils/address->checksum web3 "0x8888f1f195afa192cfee860698584c030f4c9db1")
+          "0x8888f1F195AFa192CfeE860698584c030f4c9dB1"))))


### PR DESCRIPTION
The way to deploy a contract has changed with regards to previously used version.
https://web3js.readthedocs.io/en/v1.7.3/web3-eth-contract.html#deploy
Now, calling to web3 deploy() just creates the contract object, and you need to call send() over the contract object to deploy it.

Also, some utils method have been adjusted to make them work with new web3.js version together with some tests