### PR TITLE
Add/fix functions to support event and block subscriptions

### DIFF
--- a/src/cljs_web3_next/core.cljs
+++ b/src/cljs_web3_next/core.cljs
@@ -26,6 +26,9 @@
   ([uri] (ws-provider uri {}))
   ([uri opts] (websocket-provider uri opts)))
 
+(defn support-subscriptions? [provider]
+  (some? (aget provider "currentProvider" "on")))
+
 (defn connection-url [provider]
   (oget provider "currentProvider" "connection" "_url"))
 


### PR DESCRIPTION
This PR adds a functions to check if the provider support subscriptions (websocket) or not (http). This is required by re-frame-web3-fx to differentiate if the event watchs are created using native web3.js subscriptions or a poll mechanism.

Additionally, it fixes a couple of functions and docs so they are compatible with web3.js 1.x.