### PR TITLE
Fix core/on-[connect/disconnect/error] implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,10 @@ Additionally CI runs the tests slightly different way, so that's the 3rd test en
 ## CI (Headless Chrome, Karma)
 
 1. Build: `npx shadow-cljs compile test-ci`
-2. Tests: ```CHROME_BIN=`which chromium-browser` npx karma start karma.conf.js --single-run```
+2. Tests:
+    ```
+    CHROME_BIN=`which chromium-browser` npx karma start karma.conf.js --single-run
+    ```
 
 #### inspect on headless chrome on another chrome instance
 

--- a/browser-test/all.cljs
+++ b/browser-test/all.cljs
@@ -2,17 +2,14 @@
   (:require-macros [cljs.test :refer [deftest testing is async]]
                    [cljs.core.async.macros :refer [go]])
   (:require [cljs.test :as t]
- #_           [tests.macros :refer [slurpit]]
             [cljs-web3-next.core :as web3-core]
             [cljs-web3-next.eth :as web3-eth]
             [cljs-web3-next.utils :as web3-utils]
             [cljs-web3-next.helpers :as web3-helpers]
             [cljs-web3-next.personal :as web3-personal]
-  #_          [cljs.nodejs :as nodejs]
             [clojure.string :as string]
             [oops.core :refer [ocall oget oset! oapply+]]
             [cljs.core.async :refer [<!]]
-#_            [tests.smart-contracts-test :refer [smart-contracts]]
             [district.shared.async-helpers :as async-helpers]))
 
 (async-helpers/extend-promises-as-channels!)

--- a/browser-test/all.cljs
+++ b/browser-test/all.cljs
@@ -20,7 +20,7 @@
 (def gas-limit 4500000)
 
 (def contract-source "
-  pragma solidity ^0.4.6;
+  pragma solidity ^0.8.0;
 
   contract test {
     function multiply(uint a) returns(uint d) {

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,10 +1,11 @@
-pragma solidity ^0.4.23;
+// 	SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
 
 contract Migrations {
   address public owner;
   uint public last_completed_migration;
 
-  constructor() public {
+  constructor() {
     owner = msg.sender;
   }
 

--- a/contracts/MyContract.sol
+++ b/contracts/MyContract.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.4.18;
+// 	SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
 
 contract MyContract {
 
@@ -9,11 +10,11 @@ contract MyContract {
   event SetCounterEvent(uint previousValue, uint newValue);
   /* event SpecialEvent(uint someParam); */
 
-  constructor(uint _counter) public {
+  constructor(uint _counter) {
     counter = _counter;
   }
 
-  function myPlus(uint a, uint b) public constant returns (uint) {
+  function myPlus(uint a, uint b) public pure returns (uint) {
     return a + b;
   }
 

--- a/contracts/auth/DSAuth.sol
+++ b/contracts/auth/DSAuth.sol
@@ -1,68 +1,56 @@
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// SPDX-License-Identifier: GNU-3
+pragma solidity >=0.4.23;
 
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-pragma solidity ^0.4.13;
-
-contract DSAuthority {
-  function canCall(
-    address src, address dst, bytes4 sig
-  ) public view returns (bool);
+interface DSAuthority {
+    function canCall(
+        address src, address dst, bytes4 sig
+    ) external view returns (bool);
 }
 
 contract DSAuthEvents {
-  event LogSetAuthority (address indexed authority);
-  event LogSetOwner     (address indexed owner);
+    event LogSetAuthority (address indexed authority);
+    event LogSetOwner     (address indexed owner);
 }
 
 contract DSAuth is DSAuthEvents {
-  DSAuthority  public  authority;
-  address      public  owner;
+    DSAuthority  public  authority;
+    address      public  owner;
 
-  function DSAuth() public {
-    owner = msg.sender;
-    LogSetOwner(msg.sender);
-  }
-
-  function setOwner(address owner_)
-  public
-  auth
-  {
-    owner = owner_;
-    LogSetOwner(owner);
-  }
-
-  function setAuthority(DSAuthority authority_)
-  public
-  auth
-  {
-    authority = authority_;
-    LogSetAuthority(authority);
-  }
-
-  modifier auth {
-    require(isAuthorized(msg.sender, msg.sig));
-    _;
-  }
-
-  function isAuthorized(address src, bytes4 sig) internal view returns (bool) {
-    if (src == address(this)) {
-      return true;
-    } else if (src == owner) {
-      return true;
-    } else if (authority == DSAuthority(0)) {
-      return false;
-    } else {
-      return authority.canCall(src, this, sig);
+    constructor() {
+        owner = msg.sender;
+        emit LogSetOwner(msg.sender);
     }
-  }
+
+    function setOwner(address owner_)
+        public
+        auth
+    {
+        owner = owner_;
+        emit LogSetOwner(owner);
+    }
+
+    function setAuthority(DSAuthority authority_)
+        public
+        auth
+    {
+        authority = authority_;
+        emit LogSetAuthority(address(authority));
+    }
+
+    modifier auth {
+        require(isAuthorized(msg.sender, msg.sig), "ds-auth-unauthorized");
+        _;
+    }
+
+    function isAuthorized(address src, bytes4 sig) internal view returns (bool) {
+        if (src == address(this)) {
+            return true;
+        } else if (src == owner) {
+            return true;
+        } else if (authority == DSAuthority(address(0))) {
+            return false;
+        } else {
+            return authority.canCall(src, address(this), sig);
+        }
+    }
 }

--- a/contracts/proxy/DelegateProxy.sol
+++ b/contracts/proxy/DelegateProxy.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.4.18;
+// 	SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
 
 contract DelegateProxy {
   /**
@@ -6,11 +7,11 @@ contract DelegateProxy {
   * @param _dst Destination address to perform the delegatecall
   * @param _calldata Calldata for the delegatecall
   */
-  function delegatedFwd(address _dst, bytes _calldata) internal {
+  function delegatedFwd(address _dst, bytes memory _calldata) internal {
     require(isContract(_dst));
     assembly {
-      let result := delegatecall(sub(gas, 10000), _dst, add(_calldata, 0x20), mload(_calldata), 0, 0)
-      let size := returndatasize
+      let result := delegatecall(sub(gas(), 10000), _dst, add(_calldata, 0x20), mload(_calldata), 0, 0)
+      let size := returndatasize()
 
       let ptr := mload(0x40)
       returndatacopy(ptr, 0, size)

--- a/contracts/proxy/Forwarder.sol
+++ b/contracts/proxy/Forwarder.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.4.18;
+// 	SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
 
 import "../proxy/DelegateProxy.sol";
 
@@ -9,7 +10,10 @@ contract Forwarder is DelegateProxy {
   /*
   * @dev Forwards all calls to target
   */
-  function() payable {
+  fallback() external payable {
     delegatedFwd(target, msg.data);
+  }
+
+  receive() external payable {
   }
 }

--- a/contracts/proxy/MutableForwarder.sol
+++ b/contracts/proxy/MutableForwarder.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.4.18;
+// 	SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
 
 import "../proxy/DelegateProxy.sol";
 import "../auth/DSAuth.sol";
@@ -27,8 +28,11 @@ contract MutableForwarder is DelegateProxy, DSAuth {
     target = _target;
   }
 
-  function() payable {
+  fallback() external payable {
     delegatedFwd(target, msg.data);
+  }
+
+  receive() external payable {
   }
 
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -5,7 +5,7 @@
  :npm-deps {:install true}
  :builds
  {:test-node {:target :node-test
-         :ns-regexp "-tests$"
+         :ns-regexp "tests.(.+)"
          :output-to "out/node-tests.js"
          :autorun false}
   :test-browser {:target :browser-test

--- a/src/deps.cljs
+++ b/src/deps.cljs
@@ -1,5 +1,6 @@
 {:npm-deps
- {"web3" "1.7.3"
+ {"web3" "1.7.3"}
+ :npm-dev-deps {
   "jsedn" "0.4.1"
   "karma" "^6.3.17"
   "karma-chrome-launcher" "^3.1.1"

--- a/test/tests/web3_tests.cljs
+++ b/test/tests/web3_tests.cljs
@@ -84,6 +84,10 @@
                (web3-eth/unsubscribe event-log-emitter)
                (web3-core/disconnect web3)
 
+               (is (some? (web3-core/on-connect web3 identity)) "Adding connect listener must succeed")
+               (is (some? (web3-core/on-disconnect web3 identity)) "Adding disconnect listener must succeed")
+               (is (some? (web3-core/on-error web3 identity)) "Adding error listener must succeed (does nothing)")
+
                (is (= "0xf652222313e28459528d920b65115c16c04f3efc82aaedc97be59f3f377c0d3f"
                       (web3-utils/solidity-sha3 web3 6)))
 

--- a/truffle.js
+++ b/truffle.js
@@ -16,7 +16,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: "0.4.23"
+      version: "0.8.0"
     }
   }
 };


### PR DESCRIPTION
The Web3.js 1.7 providers (e.g. MetaMask) doesn't have on-error listener
anymore. This caused error on server-web3 mount module starting up
https://github.com/district0x/district-server-web3/blob/6ce7f0243c10901ea106d6871d0725b89aa0a1f9/src/district/server/web3.cljs#L107

The only events are: _'connect'_ and _'disconnect'_ - https://docs.metamask.io/guide/ethereum-provider.html#events