### PR TITLE
Implement test RPC methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ Latest released version of this library: <br>
   - [to-wei](#to-wei)
   - [address?](#address?)
 - [cljs-web3.evm](#evm)
-  - [increase-time](#increase-time)
-  - [mine-block](#mine-block)
+  - [increase-time!](#increase-time!)
+  - [mine-block!](#mine-block!)
+  - [snapshot!](#snapshot!)
+  - [revert!](#revert!)
 - [cljs-web3.helpers](#helpers)
   - [js->cljkk](#js->cljkk)
   - [cljkk->js](#cljkk->js)
@@ -458,17 +460,29 @@ Implementation of Solidity sha3 function. Takes a web3 provider and a variable n
 *NOTE* The functions in this namespaces are not a part of the API unless you [extend](#extend) the `evm` module with these RPC calls.
 They will only to work with a testrpc such as [ganache](https://www.trufflesuite.com/ganache)
 
-#### <a name="increase-time">`increase-time`
+#### <a name="increase-time!">`increase-time!`
 
-Increases the blockchain time by the specified numebr of seconds.
+Increases the blockchain time by the specified number of seconds.
 
-`(increase-time web3 seconds)`
+`(increase-time! web3 [seconds] callback)`
 
-#### <a name="mine-block">`mine-block`
+#### <a name="mine-block!">`mine-block!`
 
 Instantly mines a block.
 
-`(mine-block web3)`
+`(mine-block web3 callback)`
+
+#### <a name="snapshot!">`snapshot!`
+
+Snapshot the state of the blockchain at the current block.
+
+`(snapshot! web3 callback)`
+
+#### <a name="snapshot!">`revert!`
+
+Revert the state of the blockchain to a previous snapshot.
+
+`(revert! web3 [snapshot-id] callback)`
 
 ### <a name="helpers">`cljs-web3.helpers`
 

--- a/src/cljs_web3_next/evm.cljs
+++ b/src/cljs_web3_next/evm.cljs
@@ -1,14 +1,121 @@
 (ns cljs-web3-next.evm
-  (:require [oops.core :refer [ocall oget]]))
+  "Functions that can be used to control testrpc behaviour. Can ONLY (!) be used
+  with testrpc.
 
-(defn increase-time [provider seconds]
-  (ocall (oget provider "evm") "increaseTime" seconds))
+  See https://github.com/ethereumjs/testrpc for more information."
+  (:require [cljs-web3-next.utils :refer [callback-js->clj js->cljkk]]))
 
-(defn mine-block [provider]
-  (ocall (oget provider "evm") "mineBlock"))
 
-(defn snapshot [provider]
-  (ocall (oget provider "evm") "snapshot"))
+(defn- jsonrpc-callback->clj
+  [callback]
+  (callback-js->clj (fn [err res]
+    (cond
+      err (callback err res)
+      (:error res) (callback (:error res) res)
+      (:result res) (callback nil (:result res))
+      :default (callback err res)))))
 
-(defn revert [provider]
-  (ocall (oget provider "evm") "revert"))
+(defn send-jsonrpc
+  "Sends a jsonrpc message to the currentProvider.
+
+  Parameter:
+  web3 - web3 instance
+
+  Example:
+  user> `(send-async-fn web3)`
+  #object..."
+  [web3 jsonrpc & [callback]]
+    (js-invoke
+           (aget web3 "currentProvider")
+           "send" jsonrpc (if callback (jsonrpc-callback->clj callback) (fn [_err _res]))))
+
+
+(defn- increase-time-jsonrpc [args]
+  (clj->js {:jsonrpc "2.0"
+            :method "evm_increaseTime"
+            :params args
+            :id (.getTime (js/Date.))}))
+
+(defn increase-time!
+  "Jump forward in time in the EVM.
+
+  Parameters:
+  web3     - web3 instance
+  args     - The amount of time to increase in seconds.
+  callback - callback with two parameters, error and result.
+
+  Results is the total time adjustment, in seconds.
+
+  Example:
+  user> `(web3-evm/increase-time! web3 [1000] callback)`"
+  [web3 args & [callback]]
+  (send-jsonrpc web3 (increase-time-jsonrpc args) callback))
+
+
+(defn- mine-block-jsonrpc []
+  (clj->js {:jsonrpc "2.0"
+            :method "evm_mine"
+            :params []
+            :id (.getTime (js/Date.))}))
+
+(defn mine-block!
+  "Force a block to be mined. Mines a block independent of
+  whether or not mining is started or stopped.
+
+  Parameters:
+  web3     - web3 instance
+  callback - callback with two parameters, error and result.
+
+  Example:
+  user> `(web3-evm/mine! web3 callback)`"
+  [web3 & [callback]]
+  (send-jsonrpc web3 (mine-block-jsonrpc) callback))
+
+
+(defn- revert-jsonrpc [args]
+  (clj->js {:jsonrpc "2.0"
+            :method "evm_revert"
+            :params args
+            :id (.getTime (js/Date.))}))
+
+(defn revert!
+  "Revert the state of the blockchain to a previous snapshot.
+
+  Takes a single
+  parameter, which is the snapshot id to revert to. If no snapshot id is passed
+  it will revert to the latest snapshot. Returns true.
+
+  Parameters:
+  web3     - web3 instance
+  args     - snapshot id to revert to, if no snapshot id is passed, it will
+             revert to the latest snapshot
+  callback - callback with two parameters, error and result.
+
+  Result is true.
+
+  Example:
+  user> `(web3-evm/revert! web3 [0] callback)`"
+  [web3 args & [callback]]
+  (send-jsonrpc web3 (revert-jsonrpc args) callback))
+
+
+(defn- snapshot-jsonrpc []
+  (clj->js {:jsonrpc "2.0"
+            :method "evm_snapshot"
+            :params []
+            :id (.getTime (js/Date.))}))
+
+(defn snapshot!
+  "Snapshot the state of the blockchain at the current block.
+
+  Parameters:
+  web3     - web3 instance
+  callback - callback with two parameters, error and result.
+
+  Result is the id of the snapshot created.
+
+  Example:
+  user> `(web3-evm/snapshot! web3 callback)`
+  "
+  [web3 & [callback]]
+  (send-jsonrpc web3 (snapshot-jsonrpc) callback))


### PR DESCRIPTION
There are some non-standard methods that are not included within the original RPC specification, but are useful for local testing (e.g., ganache), especially for testing contracts with time limitations.

See https://docs.nethereum.com/en/latest/ethereum-and-clients/ganache-cli/

This methods are not implemented on web3.js, so they need to be implemented by making jsonrpc calls directly to the web3 provider