### PR TITLE
Add get-chain-id method

### DIFF
--- a/src/cljs_web3_next/eth.cljs
+++ b/src/cljs_web3_next/eth.cljs
@@ -19,6 +19,9 @@
 ;; (defn get-balance [provider address]
 ;;   (ocall provider "eth" "getBalance" address))
 
+(defn get-chain-id [provider & [callback]]
+  (oapply+ provider "eth.getChainId" (remove nil? [callback])))
+
 (defn get-block-number [provider & [callback]]
   (oapply+ provider "eth.getBlockNumber" (remove nil? [callback])))
 

--- a/test/tests/web3_tests.cljs
+++ b/test/tests/web3_tests.cljs
@@ -37,6 +37,7 @@
              (let [connected? (<! (web3-eth/is-listening? web3))
                    accounts (<! (web3-eth/accounts web3))
                    block-number (<! (web3-eth/get-block-number web3))
+                   chain-id (<! (web3-eth/get-chain-id web3))
                    block (js->clj (<! (web3-eth/get-block web3 block-number false)) :keywordize-keys true)
                    address (-> smart-contracts :my-contract :address)
                    my-contract (web3-eth/contract-at web3 abi address)
@@ -71,6 +72,7 @@
 
 
                (is (= "7" seven))
+               (is (= "1337" (str chain-id)))
                (is (= "0x8bb5d9c30000000000000000000000000000000000000000000000000000000000000003" (web3-eth/encode-abi my-contract :set-counter [3])))
                (is (= (string/lower-case address) (string/lower-case (aget my-contract "_address"))))
                (is (aget tx-receipt "status"))


### PR DESCRIPTION
This PR adds a function to get the identifier of the current network the web3 provider is connected to.

This is needed to upgrade [district-ui-web3-chain](https://github.com/district0x/district-ui-web3-chain)
