### PR TITLE
Get injected metamask provider from window.ethereum

### DIFF
--- a/src/cljs_web3_next/core.cljs
+++ b/src/cljs_web3_next/core.cljs
@@ -60,7 +60,7 @@
 ;; 'undefined'
 
 (defn default-web3 []
-  (new Web3 (gget ".?web3.?currentProvider" )))
+  (new Web3 (or (gget ".?ethereum" ) (gget ".?web3.?currentProvider" ))))
 
 
 (def version-ethereum


### PR DESCRIPTION
Metamask changed the way how it injects the current web3 provider API. It used to set it on _window.web3_, but now this is deprecated in favor of _window.ethereum_.
Using _window.web3_ still works, but it shows a warning informing that the site is trying to use the legacy version.

This PR changes how we get the default injected API. If first tries to get the current provider from _window.ethereum_ and only fallbacks to _window.web3_ if the former is not available