### PR TITLE
Fix create-web3 and contract-get-data

### DIFF
--- a/src/cljs_web3_next/core.cljs
+++ b/src/cljs_web3_next/core.cljs
@@ -390,7 +390,7 @@
   "
   ([url]
    (create-web3 (default-web3) url))
-  ([url provider]
+  ([provider url]
    (cond
      (not (nil? provider)) (new Web3 provider)
      (clojure.string/starts-with? "http" url) (http-provider url)

--- a/src/cljs_web3_next/eth.cljs
+++ b/src/cljs_web3_next/eth.cljs
@@ -325,6 +325,8 @@
   (unsubscribe filter (first args)))
 
 
+;; DEPRECATED
+;; Use (encode-abi ) instead
 (defn contract-get-data
   "Gets binary data of a contract method call.
 
@@ -341,11 +343,7 @@
   user> `(web3-eth/contract-call ContractInstance :multiply 5)`
   25"
   [contract-instance method & args]
-  (let [method-name (web3-helpers/camel-case (name method))
-        method-fn (oget+ contract-instance method-name)]
-    (if method-fn
-      (ocall method-fn "getData" args)
-      (throw (str "Method: " method-name " was not found in object.")))))
+  (encode-abi contract-instance method args))
 
 
 ;; DEPRECATED


### PR DESCRIPTION
_create-web3_ was introducing a breaking change with regards to cljs-web3 by changing the order of the parameters. Besides, it was also introducing a bug, because calling the method with just the URL was assuming the opposite order as well.

So this PR reorder the parameters as expected.

Additionally, it deprecates the method _contract-get-data_ as this is no longer part of web3.js. Now, it fallbacks to encode-abi, which is the equivalent method to use.